### PR TITLE
OF-43: Create frontend images/containers based on distro-reffapp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,5 +192,16 @@
 			</snapshots>
 		</pluginRepository>
 	</pluginRepositories>
-
+	<distributionManagement>
+		<repository>
+			<id>github</id>
+			<name>GitHub csaude Apache Maven Packages</name>
+			<url>https://maven.pkg.github.com/csaude/openmrs-module-eptsreports</url>
+		</repository>
+		<snapshotRepository>
+			<id>github</id>
+			<name>GitHub csaude Apache Maven Packages</name>
+			<url>https://maven.pkg.github.com/csaude/openmrs-module-eptsreports</url>
+		</snapshotRepository>
+	</distributionManagement>
 </project>


### PR DESCRIPTION
This allows us to deploy this package to [GitHub registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry).